### PR TITLE
[ci] Build project on pull request not push

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -1,6 +1,6 @@
 name: CMake
 
-on: [push]
+on: [pull_request]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)


### PR DESCRIPTION
This allows branches to be tested downloaded on different machines
without worrying about constantly rebuilding.